### PR TITLE
Validate Host and Origin headers on the HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ The `uvx` command runs the server in a temporary environment without requiring a
 - `GCORE_CLOUD_PROJECT_ID`: "1",
 - `GCORE_CLOUD_REGION_ID`: "76",
 - `GCORE_CLIENT_ID`: "2",
+- `GCORE_ALLOWED_HOSTS`: "127.0.0.1:*,localhost:*,[::1]:*" (HTTP transport only)
+- `GCORE_ALLOWED_ORIGINS`: "" (HTTP transport only)
+
+### HTTP transport security
+
+The HTTP transport (`GCORE_TRANSPORT=http`) validates the `Host` and `Origin`
+headers of every request, as required by the MCP Streamable HTTP specification.
+This prevents a web page the operator visits from reaching a listener bound to
+loopback via DNS rebinding.
+
+- `GCORE_ALLOWED_HOSTS` is a comma-separated allow-list of `Host` values.
+  A trailing `:*` matches any port. Defaults to loopback only; set it when the
+  server is reached under a different name. A request with an unlisted `Host`
+  is rejected with `421 Misdirected Request`.
+- `GCORE_ALLOWED_ORIGINS` is a comma-separated allow-list of `Origin` values.
+  It is empty by default, meaning no browser origin is accepted. Requests
+  without an `Origin` header — which is every non-browser MCP client — are
+  unaffected. A request with an unlisted `Origin` is rejected with `403`.
+
+The HTTP transport does **not** authenticate clients: anyone who can reach the
+listener can call every enabled tool using the server's `GCORE_API_KEY`. Bind it
+to loopback and do not expose it to an untrusted network.
 
 ## Configuration
 

--- a/gcore_mcp_server/http_security.py
+++ b/gcore_mcp_server/http_security.py
@@ -1,0 +1,86 @@
+"""Host/Origin allowlisting for the HTTP transport (DNS-rebinding protection)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Sequence
+
+from starlette.datastructures import Headers
+from starlette.middleware import Middleware
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger("gcore-mcp")
+
+DEFAULT_ALLOWED_HOSTS: tuple[str, ...] = ("127.0.0.1:*", "localhost:*", "[::1]:*")
+ALLOWED_HOSTS_ENV_VAR = "GCORE_ALLOWED_HOSTS"
+ALLOWED_ORIGINS_ENV_VAR = "GCORE_ALLOWED_ORIGINS"
+
+
+def _split(raw: str | None) -> list[str]:
+    return [item.strip() for item in (raw or "").split(",") if item.strip()]
+
+
+def _matches(value: str, allowed: Sequence[str]) -> bool:
+    for pattern in allowed:
+        if pattern == value:
+            return True
+        if pattern.endswith(":*") and value.startswith(pattern[:-1]):
+            return True
+    return False
+
+
+class TransportSecurityMiddleware:
+    """Reject requests whose Host or Origin header is not allowlisted."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        allowed_hosts: Sequence[str],
+        allowed_origins: Sequence[str],
+    ) -> None:
+        self.app = app
+        self.allowed_hosts = list(allowed_hosts)
+        self.allowed_origins = list(allowed_origins)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+
+        host = headers.get("host")
+        if not host or not _matches(host, self.allowed_hosts):
+            logger.warning("Rejected request with Host header: %r", host)
+            await PlainTextResponse("Invalid Host header", status_code=421)(
+                scope, receive, send
+            )
+            return
+
+        # An absent Origin means a non-browser client; only browsers set it.
+        origin = headers.get("origin")
+        if origin and not _matches(origin, self.allowed_origins):
+            logger.warning("Rejected request with Origin header: %r", origin)
+            await PlainTextResponse("Invalid Origin header", status_code=403)(
+                scope, receive, send
+            )
+            return
+
+        await self.app(scope, receive, send)
+
+
+def build_http_middleware() -> list[Middleware]:
+    """Build the middleware stack for the HTTP transport."""
+    hosts = _split(os.getenv(ALLOWED_HOSTS_ENV_VAR)) or list(DEFAULT_ALLOWED_HOSTS)
+    origins = _split(os.getenv(ALLOWED_ORIGINS_ENV_VAR))
+    logger.info("HTTP transport allowed hosts: %s", hosts)
+    logger.info("HTTP transport allowed origins: %s", origins or "<none>")
+    return [
+        Middleware(
+            TransportSecurityMiddleware,
+            allowed_hosts=hosts,
+            allowed_origins=origins,
+        )
+    ]

--- a/gcore_mcp_server/http_security.py
+++ b/gcore_mcp_server/http_security.py
@@ -19,10 +19,19 @@ ALLOWED_ORIGINS_ENV_VAR = "GCORE_ALLOWED_ORIGINS"
 
 
 def _split(raw: str | None) -> list[str]:
-    return [item.strip() for item in (raw or "").split(",") if item.strip()]
+    """Parse a comma-separated allow-list, normalized for case-insensitive use."""
+    return [item.strip().lower() for item in (raw or "").split(",") if item.strip()]
 
 
 def _matches(value: str, allowed: Sequence[str]) -> bool:
+    """Match a Host/Origin value against the allow-list.
+
+    Hostnames and URI schemes are case-insensitive (RFC 3986 §3.1, §3.2.2), and
+    neither a Host nor an Origin header carries a case-sensitive component, so
+    the whole value is compared lower-cased. Allow-list entries are already
+    normalized by `_split`. A trailing `:*` matches any port.
+    """
+    value = value.strip().lower()
     for pattern in allowed:
         if pattern == value:
             return True

--- a/gcore_mcp_server/server.py
+++ b/gcore_mcp_server/server.py
@@ -12,8 +12,10 @@ Gcore API → Model-Context-Protocol bridge (FastMCP v2)
     – "http"/"stream" …… streamable HTTP transport (suitable for remote)
   In HTTP mode the *management* tool-set is enabled by default unless
   `GCORE_TOOLS` is provided explicitly.
-• OAuth2/JWT will be added later.  `AuthSettings` is left commented for future
-  wiring.
+• In HTTP mode the listener validates the Host and Origin headers against
+  allow-lists (`GCORE_ALLOWED_HOSTS` / `GCORE_ALLOWED_ORIGINS`), as required by
+  the MCP Streamable HTTP specification.  Client authentication (OAuth2/JWT) is
+  not implemented yet — do not expose the listener to an untrusted network.
 
 Requires `fastmcp>=2.2` and the official «gcore» Python SDK.
 """
@@ -38,6 +40,7 @@ from gcore_mcp_server.config.settings import (
     generate_short_tool_name,
 )
 from gcore_mcp_server.config.toolsets import get_allowed_tools_list
+from gcore_mcp_server.http_security import build_http_middleware
 from gcore_mcp_server.domain import (
     MCP_PROJECT_REGION_INSTRUCTIONS,
     PROJECT_ID_TOOL_NOTE,
@@ -392,6 +395,7 @@ def main() -> None:
             transport=TRANSPORT,
             port=port,
             log_level="INFO",
+            middleware=build_http_middleware(),
         )  # type: ignore[arg-type]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "gcore>=0.55,<1",
     "fastmcp>=2.12.0,<3",
+    "starlette>=0.47.2",
 ]
 
 [project.optional-dependencies]
@@ -55,6 +56,7 @@ python_files = "test_*.py"
 [dependency-groups]
 dev = [
     "build>=1.2.2.post1",
+    "httpx>=0.28.1",
     "pyright>=1.1.397",
     "pytest>=8.3.5",
     "pytest-anyio>=0.0.0",

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -50,6 +50,16 @@ class TestHostValidation:
         response = client.post("/mcp", headers={"Host": "rebind.attacker.example"})
         assert response.status_code == 421
 
+    @pytest.mark.parametrize("host", ["Localhost:8000", "LOCALHOST:8000"])
+    def test_host_matching_is_case_insensitive(self, host: str):
+        """Hostnames are case-insensitive (RFC 3986 3.2.2)."""
+        client = _build_client({})
+        assert client.post("/mcp", headers={"Host": host}).status_code == 200
+
+    def test_configured_host_matching_is_case_insensitive(self):
+        client = _build_client({ALLOWED_HOSTS_ENV_VAR: "MCP.Internal:8000"})
+        assert client.post("/mcp", headers={"Host": "mcp.internal:8000"}).status_code == 200
+
     def test_allowlist_is_configurable(self):
         client = _build_client({ALLOWED_HOSTS_ENV_VAR: "mcp.internal:8000"})
         assert client.post("/mcp", headers={"Host": "mcp.internal:8000"}).status_code == 200
@@ -74,6 +84,15 @@ class TestOriginValidation:
 
     def test_allowlisted_origin_is_accepted(self):
         client = _build_client({ALLOWED_ORIGINS_ENV_VAR: "https://app.example.com"})
+        response = client.post(
+            "/mcp",
+            headers={"Host": "127.0.0.1:8000", "Origin": "https://app.example.com"},
+        )
+        assert response.status_code == 200
+
+    def test_origin_matching_is_case_insensitive(self):
+        """Scheme and host of an Origin are case-insensitive (RFC 3986 3.1, 3.2.2)."""
+        client = _build_client({ALLOWED_ORIGINS_ENV_VAR: "HTTPS://App.Example.com"})
         response = client.post(
             "/mcp",
             headers={"Host": "127.0.0.1:8000", "Origin": "https://app.example.com"},

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -1,0 +1,98 @@
+"""Tests for Host/Origin validation on the HTTP transport."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from gcore_mcp_server.http_security import (
+    ALLOWED_HOSTS_ENV_VAR,
+    ALLOWED_ORIGINS_ENV_VAR,
+    DEFAULT_ALLOWED_HOSTS,
+    build_http_middleware,
+)
+
+
+def _build_client(env: dict[str, str]) -> TestClient:
+    """Build a test app whose middleware is configured from `env`."""
+    with patch.dict(os.environ, env, clear=False):
+        for var in (ALLOWED_HOSTS_ENV_VAR, ALLOWED_ORIGINS_ENV_VAR):
+            if var not in env:
+                os.environ.pop(var, None)
+        app = Starlette(
+            routes=[Route("/mcp", lambda _: PlainTextResponse("ok"), methods=["POST"])],
+            middleware=build_http_middleware(),
+        )
+    return TestClient(app, base_url="http://127.0.0.1:8000")
+
+
+class TestHostValidation:
+    """The Host header must match the allowlist."""
+
+    def test_loopback_is_allowed_by_default(self):
+        client = _build_client({})
+        assert client.post("/mcp", headers={"Host": "127.0.0.1:8000"}).status_code == 200
+
+    def test_default_allowlist_is_loopback_only(self):
+        assert DEFAULT_ALLOWED_HOSTS == ("127.0.0.1:*", "localhost:*", "[::1]:*")
+
+    @pytest.mark.parametrize("host", ["localhost:9999", "[::1]:8000"])
+    def test_wildcard_port_matches_any_port(self, host: str):
+        client = _build_client({})
+        assert client.post("/mcp", headers={"Host": host}).status_code == 200
+
+    def test_rebinding_host_is_rejected(self):
+        client = _build_client({})
+        response = client.post("/mcp", headers={"Host": "rebind.attacker.example"})
+        assert response.status_code == 421
+
+    def test_allowlist_is_configurable(self):
+        client = _build_client({ALLOWED_HOSTS_ENV_VAR: "mcp.internal:8000"})
+        assert client.post("/mcp", headers={"Host": "mcp.internal:8000"}).status_code == 200
+        assert client.post("/mcp", headers={"Host": "127.0.0.1:8000"}).status_code == 421
+
+
+class TestOriginValidation:
+    """The Origin header, when present, must match the allowlist."""
+
+    def test_absent_origin_is_allowed(self):
+        """Non-browser MCP clients do not send Origin and must keep working."""
+        client = _build_client({})
+        assert client.post("/mcp", headers={"Host": "127.0.0.1:8000"}).status_code == 200
+
+    def test_no_origin_is_allowlisted_by_default(self):
+        client = _build_client({})
+        response = client.post(
+            "/mcp",
+            headers={"Host": "127.0.0.1:8000", "Origin": "https://app.example.com"},
+        )
+        assert response.status_code == 403
+
+    def test_allowlisted_origin_is_accepted(self):
+        client = _build_client({ALLOWED_ORIGINS_ENV_VAR: "https://app.example.com"})
+        response = client.post(
+            "/mcp",
+            headers={"Host": "127.0.0.1:8000", "Origin": "https://app.example.com"},
+        )
+        assert response.status_code == 200
+
+    def test_rebinding_origin_is_rejected(self):
+        """A DNS-rebound page reaches the loopback listener but keeps its Origin."""
+        client = _build_client({ALLOWED_ORIGINS_ENV_VAR: "https://app.example.com"})
+        response = client.post(
+            "/mcp",
+            headers={"Host": "127.0.0.1:8000", "Origin": "https://evil.example"},
+        )
+        assert response.status_code == 403
+
+    def test_host_is_checked_before_origin(self):
+        client = _build_client({ALLOWED_ORIGINS_ENV_VAR: "https://app.example.com"})
+        response = client.post(
+            "/mcp",
+            headers={"Host": "rebind.attacker.example", "Origin": "https://evil.example"},
+        )
+        assert response.status_code == 421

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "gcore" },
+    { name = "starlette" },
 ]
 
 [package.optional-dependencies]
@@ -439,6 +440,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-anyio" },
@@ -452,12 +454,14 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-anyio", marker = "extra == 'dev'", specifier = ">=0.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "starlette", specifier = ">=0.47.2" },
 ]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.2.post1" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pyright", specifier = ">=1.1.397" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },


### PR DESCRIPTION
## What

The Streamable HTTP transport (`GCORE_TRANSPORT=http`) served any request that reached the listener without checking the `Host` or `Origin` header. The MCP Streamable HTTP spec requires servers to validate `Origin` — without it, a page the operator visits can reach a loopback-bound listener via DNS rebinding and drive the server's tools using the operator's `GCORE_API_KEY`.

`fastmcp` never passes `security_settings` to `StreamableHTTPSessionManager`, so the mcp SDK's `TransportSecurityMiddleware` is built with protection disabled and there is no way to enable it from the outside. This adds the equivalent check as ASGI middleware, through the `middleware` hook `fastmcp` already exposes on `run()` — no fork, no monkeypatch.

## Behaviour

| Header | Env var | Default | Rejection |
|---|---|---|---|
| `Host` | `GCORE_ALLOWED_HOSTS` | `127.0.0.1:*,localhost:*,[::1]:*` | `421` |
| `Origin` | `GCORE_ALLOWED_ORIGINS` | empty (no browser origin accepted) | `403` |

A trailing `:*` matches any port. **Requests with no `Origin` header pass** — only browsers set it, so every non-browser MCP client is unaffected. The `stdio` transport is untouched.

